### PR TITLE
Support type alias in go 1.22+

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -227,7 +227,7 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiext.JSONSchema
 	}
 	// NB(directxman12): if there are dot imports, this might be an external reference,
 	// so use typechecking info to get the actual object
-	typeNameInfo := typeInfo.(*types.Named).Obj()
+	typeNameInfo := convert(typeInfo)
 	pkg := typeNameInfo.Pkg()
 	pkgPath := loader.NonVendorPath(pkg.Path())
 	if pkg == ctx.pkg.Types {

--- a/pkg/crd/types_122.go
+++ b/pkg/crd/types_122.go
@@ -1,0 +1,16 @@
+//go:build go1.22
+// +build go1.22
+
+package crd
+
+import "go/types"
+
+func convert(in types.Type) *types.TypeName {
+	switch in.(type) {
+	case *types.Named:
+		return in.(*types.Named).Obj()
+	case *types.Alias:
+		return in.(*types.Alias).Obj()
+	}
+	return nil
+}

--- a/pkg/crd/types_pre_122.go
+++ b/pkg/crd/types_pre_122.go
@@ -1,0 +1,13 @@
+//go:build !go1.22
+// +build !go1.22
+
+package crd
+
+import "go/types"
+
+func convert(in types.Type) *types.TypeName {
+	if r, ok := in.(*types.Named); ok {
+		return r.Obj()
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
